### PR TITLE
Added jacaco plugin

### DIFF
--- a/lemon-demo-jpa/pom.xml
+++ b/lemon-demo-jpa/pom.xml
@@ -50,6 +50,27 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacacoVersion}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+			</plugin>
+
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
+		<jacacoVersion>0.8.7</jacacoVersion>
 	</properties>
 
     <!-- Add Spring repositories -->


### PR DESCRIPTION
#27

I was unable to run tests for lemon-demo-reactive project, could not set up mongo database. Therefore I added jacaco plugin only for lemon-demo-jpa.

It would be great if you provide test configuration for lemon-demo-reactive project.



Html report can be found in: `target/site/jacaco`
lemon-demo-jpa report:
![jacaco](https://user-images.githubusercontent.com/44961501/131508521-816cda09-07a7-47ab-b48b-5f359e02f643.png)
