### PR TITLE
Added docker-compose for testing environment

### DIFF
--- a/lemon-demo-reactive/docker-compose.yml
+++ b/lemon-demo-reactive/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+
+  database-test:
+    image: mongo:3.2.20
+    environment:
+      MONGO_INITDB_DATABASE: lemontest
+    ports:
+      - 27017:27017
+    volumes:
+      - mongo_data:/data/db
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
#45 
Added docker-compose.yml file with one container for mongo database.
I think we can add same files for other projects too, if they require some services.

To start the container run in lemon-demo-reactive project folder: `docker-compose up` and you will be able to connect to mongodb via `localhost:27017` or `127.0.0.1:27017`

docker and docker-compose should be installed on the computer to do so.